### PR TITLE
fix: wrap export page search params in suspense

### DIFF
--- a/src/app/[locale]/admin/export/page.tsx
+++ b/src/app/[locale]/admin/export/page.tsx
@@ -1,16 +1,27 @@
+import { Suspense, use } from 'react'
+
 import { ExportPage } from '@/components/ExportPage'
+import { ExportPageSkeleton } from '@/components/ExportPageSkeleton'
 
 interface ExportPageSearchParams {
   apiUrl?: string
 }
 
-export default async function ExportResultPage({
+function ExportPageWrapper({ searchParams }: { searchParams: Promise<ExportPageSearchParams> }) {
+  const params = use(searchParams)
+  const apiUrl = params.apiUrl ?? ''
+
+  return <ExportPage apiUrl={apiUrl} />
+}
+
+export default function ExportResultPage({
   searchParams
 }: {
   searchParams: Promise<ExportPageSearchParams>
 }) {
-  const params = await searchParams
-  const apiUrl = params.apiUrl ?? ''
-
-  return <ExportPage apiUrl={apiUrl} />
+  return (
+    <Suspense fallback={<ExportPageSkeleton />}>
+      <ExportPageWrapper searchParams={searchParams} />
+    </Suspense>
+  )
 }

--- a/src/components/ExportPageSkeleton.tsx
+++ b/src/components/ExportPageSkeleton.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { Loader2 } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+import { Card } from '@/components/ui/Card'
+
+export function ExportPageSkeleton() {
+  const t = useTranslations('ExportPage')
+
+  return (
+    <div className="flex min-h-48 items-center justify-center">
+      <Card className="flex min-w-72 flex-col items-center gap-4 p-8 text-center">
+        <Loader2 className="h-8 w-8 animate-spin text-blue-600" aria-hidden />
+        <div>
+          <p className="font-semibold text-gray-900">{t('preparing')}</p>
+          <p className="mt-1 text-sm text-gray-500">{t('preparing_subtitle')}</p>
+        </div>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
Root cause: /[locale]/admin/export accessed searchParams outside a Suspense boundary during next build, which broke the Docker buildx job on master. 